### PR TITLE
Minor fixes for building with gcc on linux platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,13 @@ $(BENCHMARK):
 	&& cd $(BUILDDIR) \
 	&& cmake $(abspath $@) \
 		-DCMAKE_BUILD_TYPE=Release -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
-	&& make
+	&& make -j
 .PHONY: $(BENCHMARK)
 
 # Make subdirs
 subdirs: $(SUBDIRS)
 .PHONY: subdirs
-$(SUBDIRS):
+$(SUBDIRS): $(BENCHMARK)
 	@echo "==> $@"
 	$(MAKE) -C $@ BENCHMARK=$(abspath $(BENCHMARK)) \
 		BUILDDIR=$(abspath $(BUILDDIR))

--- a/memory-latency/Makefile
+++ b/memory-latency/Makefile
@@ -9,7 +9,7 @@ BENCHMARK ?= ../benchmark
 CXXFLAGS  += -I$(BENCHMARK)/include \
              -Wall -Wextra -Wpedantic -Wshadow -Wpointer-arith \
              -Wcast-qual -Werror -std=c++17 -O3 -g
-LDFLAGS   += -L$(BUILDDIR)/src -lbenchmark
+LDFLAGS   += -L$(BUILDDIR)/src -lbenchmark -pthread
 
 PROG       = $(basename $(word 1, $(wildcard *.cpp)))
 OBJS       = ${PROG}.o

--- a/memory-latency/memory-latency.cpp
+++ b/memory-latency/memory-latency.cpp
@@ -10,9 +10,9 @@
 #include "benchmark/benchmark.h"
 
 // User-defined literals
-auto constexpr operator"" _B(uint64_t n) { return n; }
-auto constexpr operator"" _KB(uint64_t n) { return n * 1024; }
-auto constexpr operator"" _M(uint64_t n) { return n * 1000 * 1000; }
+auto constexpr operator"" _B(unsigned long long int n) { return n; }
+auto constexpr operator"" _KB(unsigned long long int n) { return n * 1024; }
+auto constexpr operator"" _M(unsigned long long int n) { return n * 1000 * 1000; }
 
 // Cache line size: 64 bytes for x86-64, 128 bytes for A64 ARMs
 const auto kCachelineSize = 64_B;

--- a/memory-loads/Makefile
+++ b/memory-loads/Makefile
@@ -8,8 +8,9 @@ BENCHMARK ?= ../benchmark
 
 CXXFLAGS  += -I$(BENCHMARK)/include \
              -Wall -Wextra -Wpedantic -Wshadow -Wpointer-arith \
-             -Wcast-qual -Werror -std=c++17 -O3 -g
-LDFLAGS   += -L$(BUILDDIR)/src -lbenchmark
+             -Wcast-qual -Werror -std=c++17 -O3 -g \
+             -Wno-uninitialized
+LDFLAGS   += -L$(BUILDDIR)/src -lbenchmark -pthread
 
 PROG       = $(basename $(word 1, $(wildcard *.cpp)))
 OBJS       = ${PROG}.o

--- a/memory-loads/memory-loads.cpp
+++ b/memory-loads/memory-loads.cpp
@@ -9,9 +9,9 @@
 #include "benchmark/benchmark.h"
 
 // User-defined literals
-auto constexpr operator"" _B(uint64_t n) { return n; }
-auto constexpr operator"" _KB(uint64_t n) { return n * 1024; }
-auto constexpr operator"" _M(uint64_t n) { return n * 1000 * 1000; }
+auto constexpr operator"" _B(unsigned long long int n) { return n; }
+auto constexpr operator"" _KB(unsigned long long int n) { return n * 1024; }
+auto constexpr operator"" _M(unsigned long long int n) { return n * 1000 * 1000; }
 
 // Cache line size: 64 bytes for x86-64, 128 bytes for A64 ARMs
 const auto kCachelineSize = 64_B;


### PR DESCRIPTION
  - fix undefined symbol for pthread
  - fix user-defined literals type
  - fixe for make -j (add dependency)
  - add  -Wno-uninitialized (especially for asm volatile)

Here are relevant errors for above fixes:

```
g++ -o memory-loads memory-loads.o -L/users/bp000174/applied-benchmarks/build/src -lbenchmark
/usr/bin/ld: /users/bp000174/applied-benchmarks/build/src/libbenchmark.a(benchmark_runner.cc.o): in function `benchmark::internal::RunBenchmark(benchmark::internal::BenchmarkInstance const&, std::vector<benchmark::BenchmarkReporter::Run, std::allocator<benchmark::BenchmarkReporter::Run> >*)':
benchmark_runner.cc:(.text+0x8ce): undefined reference to `pthread_create'

....

In file included from memory-loads.cpp:9:
/users/bp000174/applied-benchmarks/benchmark/include/benchmark/benchmark.h: In function 'void cache_conflicts_array(benchmark::State&)':
/users/bp000174/applied-benchmarks/benchmark/include/benchmark/benchmark.h:324:48: error: 'cur_element' may be used uninitialized in this function [-Werror=maybe-uninitialized]
   asm volatile("" : "+m,r"(value) : : "memory");

// make -j will trigger

g++ -o memory-latency memory-latency.o -L/users/bp000174/applied-benchmarks/build/src -lbenchmark -pthread
/usr/bin/ld: cannot find -lbenchmark
collect2: error: ld returned 1 exit status
```