### PR TITLE
#3 fix constexpr having space after "" even though arg is not string literal

### DIFF
--- a/memory-latency/memory-latency.cpp
+++ b/memory-latency/memory-latency.cpp
@@ -10,9 +10,9 @@
 #include "benchmark/benchmark.h"
 
 // User-defined literals
-auto constexpr operator"" _B(unsigned long long int n) { return n; }
-auto constexpr operator"" _KB(unsigned long long int n) { return n * 1024; }
-auto constexpr operator"" _M(unsigned long long int n) { return n * 1000 * 1000; }
+auto constexpr operator""_B(unsigned long long int n) { return n; }
+auto constexpr operator""_KB(unsigned long long int n) { return n * 1024; }
+auto constexpr operator""_M(unsigned long long int n) { return n * 1000 * 1000; }
 
 // Cache line size: 64 bytes for x86-64, 128 bytes for A64 ARMs
 const auto kCachelineSize = 64_B;

--- a/memory-loads/memory-loads.cpp
+++ b/memory-loads/memory-loads.cpp
@@ -9,9 +9,9 @@
 #include "benchmark/benchmark.h"
 
 // User-defined literals
-auto constexpr operator"" _B(unsigned long long int n) { return n; }
-auto constexpr operator"" _KB(unsigned long long int n) { return n * 1024; }
-auto constexpr operator"" _M(unsigned long long int n) { return n * 1000 * 1000; }
+auto constexpr operator""_B(unsigned long long int n) { return n; }
+auto constexpr operator""_KB(unsigned long long int n) { return n * 1024; }
+auto constexpr operator""_M(unsigned long long int n) { return n * 1000 * 1000; }
 
 // Cache line size: 64 bytes for x86-64, 128 bytes for A64 ARMs
 const auto kCachelineSize = 64_B;


### PR DESCRIPTION
fix constexpr having space after "" even though arg is not string literal

https://en.cppreference.com/w/cpp/language/user_literal it fixes compilation in cygwin with gcc version 12.4.0

memory-latency.cpp:13:24: error: expected suffix identifier
   13 | auto constexpr operator"" _B(unsigned long long int n) { return n; }
      |                        ^~
memory-latency.cpp:18:29: error: unable to find numeric literal operator ‘operator""_B’
   18 | const auto kCachelineSize = 64_B;
memory-loads.cpp:345:23: error: ‘operator""_B’ was not declared in this scope; did you mean ‘operator""_M’?
  345 |   const auto offset = operator""_B(state.range(1));